### PR TITLE
Stick image to the top of the screen and resize image placeholder

### DIFF
--- a/flutter-frontend/lib/news_screen.dart
+++ b/flutter-frontend/lib/news_screen.dart
@@ -57,10 +57,17 @@ class _NewsScreenContainerState extends State<NewsScreenContainer> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [
-                    CachedNetworkImage(
+                    SizedBox(
+                      height: MediaQuery.of(context).size.height /
+                          3, // Set height to one-third of the screen height
+                      width: double.infinity, // Use full width
+                      child: CachedNetworkImage(
                         placeholder: (context, url) =>
                             const CircularProgressIndicator(),
-                        imageUrl: newsCards[index].imageUrl.toString()),
+                        imageUrl: newsCards[index].imageUrl.toString(),
+                        fit: BoxFit.cover,
+                      ),
+                    ),
                     Text(
                       '${newsCards[index].title}',
                       key: Key('$index-title'),


### PR DESCRIPTION
Stick each story image to the top of the screen under the SafeArea and Set height of the image to ⅓rd of the screen  and make full width

![image](https://github.com/aabid-ism/mocco/assets/62067185/3061ea88-f0c7-45e0-bfc9-5adfb3170d4a)
![image](https://github.com/aabid-ism/mocco/assets/62067185/a3ceb65b-6ce4-486a-9dd8-b714e5aefdd0)
