### PR TITLE
Set aspect ratio to cached image to avoid stretched out progress indic…

### DIFF
--- a/flutter-frontend/lib/news_screen.dart
+++ b/flutter-frontend/lib/news_screen.dart
@@ -58,14 +58,17 @@ class _NewsScreenContainerState extends State<NewsScreenContainer> {
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [
                     SizedBox(
-                      height: MediaQuery.of(context).size.height /
-                          3, // Set height to one-third of the screen height
-                      width: double.infinity, // Use full width
-                      child: CachedNetworkImage(
-                        placeholder: (context, url) =>
-                            const CircularProgressIndicator(),
-                        imageUrl: newsCards[index].imageUrl.toString(),
-                        fit: BoxFit.cover,
+                      height: MediaQuery.of(context).size.height / 3,
+                      width: double.infinity,
+                      child: AspectRatio(
+                        aspectRatio: 16 / 9,
+                        child: CachedNetworkImage(
+                          placeholder: (context, url) => const Center(
+                            child: CircularProgressIndicator(),
+                          ),
+                          imageUrl: newsCards[index].imageUrl.toString(),
+                          fit: BoxFit.cover,
+                        ),
                       ),
                     ),
                     Text(


### PR DESCRIPTION
Set aspect ratio to cached image to avoid stretched out progress indicator due to SizedBox width

![image](https://github.com/aabid-ism/mocco/assets/62067185/fe479928-e6ff-4d3c-837d-bd4c8cf41845)
![image](https://github.com/aabid-ism/mocco/assets/62067185/f41eb6d6-ea1a-4a31-93b5-ecdafdd207bf)
