### PR TITLE
Edit api fix and secondary tag ui update

### DIFF
--- a/react-admin/src/components/ManageNewsHistoryForm.jsx
+++ b/react-admin/src/components/ManageNewsHistoryForm.jsx
@@ -5,9 +5,8 @@ import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import {
-  Checkbox,
+  Autocomplete,
   Chip,
-  ListItemText,
   MenuItem,
   TextareaAutosize,
   Tooltip,
@@ -175,17 +174,9 @@ const ManageNewsHistoryForm = ({ selectedNews, handleSubmitFunc }) => {
   });
 
   // function to handle the secondary news tag drop down
-  const handleSecondaryTagChange = (e) => {
-    const { value, checked } = e.target;
-    if (checked) {
-      // Add the selected secondary tag to the state
-      setSelectedSecondaryTags((prevTags) => [...prevTags, value]);
-    } else {
-      // Remove the unselected secondary tag from the state
-      setSelectedSecondaryTags((prevTags) =>
-        prevTags.filter((tag) => tag !== value)
-      );
-    }
+  const handleSecondaryTagChange = (e, values) => {
+    const selectedValues = values.map(({ topic }) => topic);
+    setSelectedSecondaryTags(selectedValues);
   };
 
   return (
@@ -447,51 +438,19 @@ const ManageNewsHistoryForm = ({ selectedNews, handleSubmitFunc }) => {
           </Box>
         </Box>
 
-        <Box sx={{ marginTop: "10px", width: "30%" }}>
+        <Box sx={{ marginTop: "10px", width: "75%" }}>
           <label htmlFor="secondaryTags">
             <Typography fontWeight="bold">Secondary News Tags</Typography>
           </label>
-          <Field
-            as={TextField}
+          <Autocomplete
             id="secondaryTags"
             name="secondaryTags"
-            select
-            variant="outlined"
-            fullWidth
-            children={
-              dropDownList
-                ? dropDownList.secondaryTags.map((item) => (
-                    <MenuItem key={item._id} value={item.topic}>
-                      <Box
-                        sx={{
-                          display: "flex",
-                          flexDirection: "row",
-                          alignItems: "center",
-                        }}
-                      >
-                        <Checkbox
-                          value={item.topic}
-                          checked={
-                            selectedSecondaryTags.includes(item.topic)
-                              ? true
-                              : false
-                          }
-                          onChange={handleSecondaryTagChange}
-                        />
-                        <ListItemText primary={item.topic} />
-                      </Box>
-                    </MenuItem>
-                  ))
-                : []
-            }
-          />
-          <ErrorMessage
-            name="secondaryTags"
-            component="div"
-            style={{
-              color: "red",
-              fontSize: "0.8rem",
-            }}
+            multiple
+            options={dropDownList ? dropDownList.secondaryTags : []}
+            getOptionLabel={(option) => option.topic}
+            renderInput={(params) => <TextField {...params} />}
+            onChange={handleSecondaryTagChange}
+            value={selectedSecondaryTags.map((value) => ({ topic: value }))}
           />
         </Box>
 

--- a/react-admin/src/components/PublishForm.jsx
+++ b/react-admin/src/components/PublishForm.jsx
@@ -4,12 +4,7 @@ import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import {
-  Checkbox,
-  ListItemText,
-  MenuItem,
-  TextareaAutosize,
-} from "@mui/material";
+import { Autocomplete, MenuItem, TextareaAutosize } from "@mui/material";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import Axios from "../utils/axios.js";
 import * as Yup from "yup";
@@ -94,17 +89,9 @@ const PublishForm = ({ handleSubmitFunc }) => {
   };
 
   // function to handle the secondary news tag drop down
-  const handleSecondaryTagChange = (e) => {
-    const { value, checked } = e.target;
-    if (checked) {
-      // Add the selected secondary tag to the state
-      setSelectedSecondaryTags((prevTags) => [...prevTags, value]);
-    } else {
-      // Remove the unselected secondary tag from the state
-      setSelectedSecondaryTags((prevTags) =>
-        prevTags.filter((tag) => tag !== value)
-      );
-    }
+  const handleSecondaryTagChange = (e, values) => {
+    const selectedValues = values.map(({ topic }) => topic);
+    setSelectedSecondaryTags(selectedValues);
   };
 
   // function that sends updated form data to the backend after confirmation from the pop up.
@@ -375,51 +362,18 @@ const PublishForm = ({ handleSubmitFunc }) => {
           </Box>
         </Box>
 
-        <Box sx={{ marginTop: "10px", width: "30%" }}>
+        <Box sx={{ marginTop: "10px", width: "75%" }}>
           <label htmlFor="secondaryTags">
             <Typography fontWeight="bold">Secondary News Tags</Typography>
           </label>
-          <Field
-            as={TextField}
+          <Autocomplete
             id="secondaryTags"
             name="secondaryTags"
-            select
-            variant="outlined"
-            fullWidth
-            children={
-              dropDownList
-                ? dropDownList.secondaryTags.map((item) => (
-                    <MenuItem key={item._id} value={item.topic}>
-                      <Box
-                        sx={{
-                          display: "flex",
-                          flexDirection: "row",
-                          alignItems: "center",
-                        }}
-                      >
-                        <Checkbox
-                          value={item.topic}
-                          checked={
-                            selectedSecondaryTags.includes(item.topic)
-                              ? true
-                              : false
-                          }
-                          onChange={handleSecondaryTagChange}
-                        />
-                        <ListItemText primary={item.topic} />
-                      </Box>
-                    </MenuItem>
-                  ))
-                : []
-            }
-          />
-          <ErrorMessage
-            name="secondaryTags"
-            component="div"
-            style={{
-              color: "red",
-              fontSize: "0.8rem",
-            }}
+            multiple
+            options={dropDownList ? dropDownList.secondaryTags : []}
+            getOptionLabel={(option) => option.topic}
+            renderInput={(params) => <TextField {...params} />}
+            onChange={handleSecondaryTagChange}
           />
         </Box>
 

--- a/server/routes/news.js
+++ b/server/routes/news.js
@@ -86,7 +86,7 @@ router.get("/get-drop-downs", async (req, res) => {
 router.post("/edit-news", async (req, res) => {
   try {
     const newsId = req.body.id;
-    const updateNews = req.body;
+    const { id, ...updateNews } = req.body;
 
     // getting references to database and collection
     const db = conn.getDb();


### PR DESCRIPTION
made a ui update for the secondary news tag since i couldn't maintain the dropdown after a single entry. In the new update, the user will be able to view the secondary news tags and is more clean. 
![image](https://github.com/aabid-ism/mocco/assets/92735170/f5f55682-d6c1-4b2a-940d-9798f442aff4)
